### PR TITLE
Fix indexing bug in OpenML classification experiment

### DIFF
--- a/scripts/openmlexperiment_class.py
+++ b/scripts/openmlexperiment_class.py
@@ -135,7 +135,7 @@ for i, bin_method in enumerate(binning_methods):
         # Get accuracy
         y_pred = cv.predict(X_test)
         accuracy = accuracy_score(y_test, y_pred)
-        accuracies[i, j, seed] = accuracy
+        accuracies[i, seed] = accuracy
         
         # Get ROC AUC
         y_pred_proba = cv.predict_proba(X_test)[:, 1]


### PR DESCRIPTION
## Summary
- remove synthetic experiment updates
- revert OpenML regression output rename
- keep fix for OpenML classification accuracy indexing

## Testing
- `python -m py_compile scripts/openmlexperiment_reg.py scripts/openmlexperiment_class.py scripts/construct_modality_skew_analysis.py`
